### PR TITLE
docs: add Javadoc-style comments to RateLimitRequest model

### DIFF
--- a/rate-limiter/rate-limiter/src/main/java/com/AdilJavaPrj/rate_limiter/model/RateLimitRequest.java
+++ b/rate-limiter/rate-limiter/src/main/java/com/AdilJavaPrj/rate_limiter/model/RateLimitRequest.java
@@ -1,18 +1,42 @@
 package com.AdilJavaPrj.rate_limiter.model;
 
+/**
+ * This class represents a request payload for the rate limiter API.
+ * It encapsulates a single field: userId, which is used to identify the client making requests.
+ */
 public class RateLimitRequest {
+
+    // The userId of the client making the request
     private String userId;
 
+    /**
+     * Default constructor required for deserialization (e.g., by Spring or Jackson).
+     */
     public RateLimitRequest() {}
 
+    /**
+     * Parameterized constructor to create a RateLimitRequest with a specific userId.
+     *
+     * @param userId the identifier of the user
+     */
     public RateLimitRequest(String userId) {
         this.userId = userId;
     }
 
+    /**
+     * Gets the userId of the request.
+     *
+     * @return the userId
+     */
     public String getUserId() {
         return userId;
     }
 
+    /**
+     * Sets the userId for this request.
+     *
+     * @param userId the identifier to set
+     */
     public void setUserId(String userId) {
         this.userId = userId;
     }


### PR DESCRIPTION
This pull request adds Javadoc-style documentation to the RateLimitRequest class in the model package. The comments provide clarity on the purpose of the class and its methods, improving overall code readability and maintainability.
Changes:
- Added class-level comment describing the role of RateLimitRequest.
- Added method-level comments for getters, setters, and constructors.
This update aligns with standard Java documentation practices and contributes to better onboarding and collaboration within the codebase.